### PR TITLE
feat: 공지사항, FAQ 등 조회 API 설계

### DIFF
--- a/src/main/java/hanium/englishfairytale/announcement/application/AnnouncementQueryService.java
+++ b/src/main/java/hanium/englishfairytale/announcement/application/AnnouncementQueryService.java
@@ -1,0 +1,43 @@
+package hanium.englishfairytale.announcement.application;
+
+import hanium.englishfairytale.announcement.application.dto.AnnouncementResponse;
+import hanium.englishfairytale.announcement.domain.Announcement;
+import hanium.englishfairytale.announcement.domain.AnnouncementRepository;
+import hanium.englishfairytale.announcement.domain.AnnouncementType;
+import hanium.englishfairytale.exception.NotFoundException;
+import hanium.englishfairytale.exception.code.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AnnouncementQueryService {
+
+    private final AnnouncementRepository announcementRepository;
+
+    @Transactional(readOnly = true)
+    public List<AnnouncementResponse> findAnnouncements(AnnouncementType announcementType) {
+        return convertToAnnouncementResponse(findAnnouncementsByType(announcementType));
+    }
+
+    private List<Announcement> findAnnouncementsByType(AnnouncementType announcementType) {
+        List<Announcement> announcements = announcementRepository.findByType(announcementType);
+        verifyAnnouncementsIsEmpty(announcements);
+        return announcements;
+    }
+
+    public void verifyAnnouncementsIsEmpty(List<Announcement> announcements) {
+        if (announcements.isEmpty()) {
+            throw new NotFoundException(ErrorCode.ANNOUNCE_NOT_FOUND);
+        }
+    }
+
+    private List<AnnouncementResponse> convertToAnnouncementResponse(List<Announcement> announcements) {
+        return announcements.stream().map(AnnouncementResponse::new).collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/hanium/englishfairytale/announcement/application/dto/AnnouncementResponse.java
+++ b/src/main/java/hanium/englishfairytale/announcement/application/dto/AnnouncementResponse.java
@@ -1,0 +1,15 @@
+package hanium.englishfairytale.announcement.application.dto;
+
+import hanium.englishfairytale.announcement.domain.Announcement;
+import lombok.Getter;
+
+@Getter
+public class AnnouncementResponse {
+    private String title;
+    private String content;
+
+    public AnnouncementResponse(Announcement announcement) {
+        this.title = announcement.getTitle();
+        this.content = announcement.getContent();
+    }
+}

--- a/src/main/java/hanium/englishfairytale/announcement/domain/Announcement.java
+++ b/src/main/java/hanium/englishfairytale/announcement/domain/Announcement.java
@@ -1,0 +1,23 @@
+package hanium.englishfairytale.announcement.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Announcement {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+    @Column(name = "title", length = 100)
+    private String title;
+    @Column(name = "content")
+    private String content;
+    @Enumerated(EnumType.STRING)
+    private AnnouncementType announcementType;
+}

--- a/src/main/java/hanium/englishfairytale/announcement/domain/AnnouncementRepository.java
+++ b/src/main/java/hanium/englishfairytale/announcement/domain/AnnouncementRepository.java
@@ -1,0 +1,7 @@
+package hanium.englishfairytale.announcement.domain;
+
+import java.util.List;
+
+public interface AnnouncementRepository {
+    List<Announcement> findByType(AnnouncementType announcementType);
+}

--- a/src/main/java/hanium/englishfairytale/announcement/domain/AnnouncementType.java
+++ b/src/main/java/hanium/englishfairytale/announcement/domain/AnnouncementType.java
@@ -1,0 +1,31 @@
+package hanium.englishfairytale.announcement.domain;
+
+import hanium.englishfairytale.exception.NotFoundException;
+import hanium.englishfairytale.exception.code.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public enum AnnouncementType {
+    NOTICE("공지사항"),
+    FAQ("FAQ"),
+    TERMS_CONDITION("이용약관"),
+    PRIVACY_POLICY("개인정보 처리방침");
+
+    private final String type;
+
+    AnnouncementType(String type) {
+        this.type = type;
+    }
+
+    public static AnnouncementType of(String typeStr) {
+        if (typeStr == null) {
+            throw new IllegalStateException();
+        }
+        for (AnnouncementType at : AnnouncementType.values()) {
+            if (at.type.equals(typeStr)) {
+                return at;
+            }
+        }
+        throw  new NotFoundException(ErrorCode.ANNOUNCEMENT_TYPE_NOT_FOUND);
+    }
+}

--- a/src/main/java/hanium/englishfairytale/announcement/infra/AnnouncementJpaRepository.java
+++ b/src/main/java/hanium/englishfairytale/announcement/infra/AnnouncementJpaRepository.java
@@ -1,0 +1,25 @@
+package hanium.englishfairytale.announcement.infra;
+
+import hanium.englishfairytale.announcement.domain.Announcement;
+import hanium.englishfairytale.announcement.domain.AnnouncementRepository;
+import hanium.englishfairytale.announcement.domain.AnnouncementType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class AnnouncementJpaRepository implements AnnouncementRepository {
+
+    private final EntityManager em;
+
+    @Override
+    public List<Announcement> findByType(AnnouncementType announcementType) {
+        return em.createQuery("select a from Announcement a" +
+                " where a.announcementType = :announcementType", Announcement.class)
+                .setParameter("announcementType", announcementType)
+                .getResultList();
+    }
+}

--- a/src/main/java/hanium/englishfairytale/announcement/infra/http/AnnouncementController.java
+++ b/src/main/java/hanium/englishfairytale/announcement/infra/http/AnnouncementController.java
@@ -1,0 +1,30 @@
+package hanium.englishfairytale.announcement.infra.http;
+
+import hanium.englishfairytale.announcement.application.AnnouncementQueryService;
+import hanium.englishfairytale.announcement.application.dto.AnnouncementResponse;
+import hanium.englishfairytale.announcement.domain.AnnouncementType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/api/v1/announcement")
+@RequiredArgsConstructor
+public class AnnouncementController {
+    private final AnnouncementQueryService announcementQueryService;
+
+    @GetMapping("")
+    public ResponseEntity<List<AnnouncementResponse>> findAnnouncements(@RequestParam String type) {
+        return new ResponseEntity<>(announcementQueryService.findAnnouncements(toEnum(type)), HttpStatus.OK);
+    }
+
+    private AnnouncementType toEnum(String type) {
+        return AnnouncementType.of(type);
+    }
+}

--- a/src/main/java/hanium/englishfairytale/exception/code/AnnouncementCode.java
+++ b/src/main/java/hanium/englishfairytale/exception/code/AnnouncementCode.java
@@ -1,0 +1,14 @@
+package hanium.englishfairytale.exception.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AnnouncementCode {
+    ANNOUNCEMENT_NOT_FOUND("A-001"),
+    NON_ANNOUNCEMENT_TYPE("A-002"),
+    ;
+
+    private final String code;
+}

--- a/src/main/java/hanium/englishfairytale/exception/code/ErrorCode.java
+++ b/src/main/java/hanium/englishfairytale/exception/code/ErrorCode.java
@@ -36,7 +36,11 @@ public enum ErrorCode {
     EXISTED_MEMBER(MemberCode.MEMBER_EXISTED.getCode(), CONFLICT, "이미 회원가입 되어있을 경우"),
     DUPLICATED_NICKNAME(MemberCode.NICKNAME_DUPLICATED.getCode(), CONFLICT, "동일한 닉네임이 존재하는 경우"),
     MEMBER_IMAGE_NON_EXISTED(MemberCode.NON_EXISTED_IMAGE.getCode(), CONFLICT, "삭제할 이미지가 존재하지 않는 경우"),
-    LOGIN_FAILED(MemberCode.FAILED_LOGIN.getCode(), NOT_FOUND, "아이디 또는 비밀번호가 일치하지 않는 경우")
+    LOGIN_FAILED(MemberCode.FAILED_LOGIN.getCode(), NOT_FOUND, "아이디 또는 비밀번호가 일치하지 않는 경우"),
+
+    // NOTICE
+    ANNOUNCE_NOT_FOUND(AnnouncementCode.ANNOUNCEMENT_NOT_FOUND.getCode(), NOT_FOUND, "DB에 해당 Announcement의 데이터가 존재하지 않는 경우"),
+    ANNOUNCEMENT_TYPE_NOT_FOUND(AnnouncementCode.NON_ANNOUNCEMENT_TYPE.getCode(), NOT_FOUND, "일치하는 AnnouncementType이 없는 경우")
     ;
 
     private final String code;

--- a/src/main/java/hanium/englishfairytale/tale/domain/ImageStatus.java
+++ b/src/main/java/hanium/englishfairytale/tale/domain/ImageStatus.java
@@ -1,8 +1,10 @@
 package hanium.englishfairytale.tale.domain;
 
-import hanium.englishfairytale.exception.BusinessException;
+import hanium.englishfairytale.exception.NotFoundException;
 import hanium.englishfairytale.exception.code.ErrorCode;
+import lombok.Getter;
 
+@Getter
 public enum ImageStatus {
     CUSTOMIZED("사용자 지정 이미지"),
     BASIC_FIRST("기본 이미지1"),
@@ -26,10 +28,6 @@ public enum ImageStatus {
                 return is;
             }
         }
-        throw new BusinessException(ErrorCode.IMAGE_STATUS_NOT_FOUND);
-    }
-
-    public String getStatus() {
-        return this.status;
+        throw new NotFoundException(ErrorCode.IMAGE_STATUS_NOT_FOUND);
     }
 }


### PR DESCRIPTION
Enum을 활용하여 하나의 엔티티로 아래의 항목들을 조회할 수 있게 설계
1. 공지사항
2. FAQ
3. 이용약관
4. 개인정보 처리방침