### PR TITLE
refactor: 동화 전체 조회API, 사용자 기존 비밀번호와 비교하는 예외처리 코드 추가

### DIFF
--- a/src/main/java/hanium/englishfairytale/exception/code/ErrorCode.java
+++ b/src/main/java/hanium/englishfairytale/exception/code/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     DUPLICATED_NICKNAME(MemberCode.NICKNAME_DUPLICATED.getCode(), CONFLICT, "동일한 닉네임이 존재하는 경우"),
     MEMBER_IMAGE_NON_EXISTED(MemberCode.NON_EXISTED_IMAGE.getCode(), CONFLICT, "삭제할 이미지가 존재하지 않는 경우"),
     LOGIN_FAILED(MemberCode.FAILED_LOGIN.getCode(), NOT_FOUND, "아이디 또는 비밀번호가 일치하지 않는 경우"),
+    INVALID_PASSWORD(MemberCode.INVALID_PASSWORD.getCode(), BAD_REQUEST, "기존의 비밀번호와 일치하지 않는 경우"),
 
     // NOTICE
     ANNOUNCE_NOT_FOUND(AnnouncementCode.ANNOUNCEMENT_NOT_FOUND.getCode(), NOT_FOUND, "DB에 해당 Announcement의 데이터가 존재하지 않는 경우"),

--- a/src/main/java/hanium/englishfairytale/exception/code/MemberCode.java
+++ b/src/main/java/hanium/englishfairytale/exception/code/MemberCode.java
@@ -11,6 +11,7 @@ public enum MemberCode {
     NICKNAME_DUPLICATED("M-003"),
     NON_EXISTED_IMAGE("M-004"),
     FAILED_LOGIN("M-005"),
+    INVALID_PASSWORD("M-006"),
     ;
 
     private final String code;

--- a/src/main/java/hanium/englishfairytale/member/application/MemberCommandService.java
+++ b/src/main/java/hanium/englishfairytale/member/application/MemberCommandService.java
@@ -34,7 +34,7 @@ public class MemberCommandService {
     @Transactional
     public Long login(MemberLoginCommand memberLoginCommand) {
         Member member = findMemberForLogin(memberLoginCommand);
-        member.verifyCorrectPassword(memberLoginCommand);
+        member.verifyMemberEmailAndPassword(memberLoginCommand);
         return member.getId();
     }
 
@@ -47,7 +47,8 @@ public class MemberCommandService {
     @Transactional
     public void updatePassword(MemberUpdatePasswordCommand updatePasswordCommand) {
         Member member = findMember(updatePasswordCommand.getMemberId());
-        member.updatePassword(updatePasswordCommand.getPassword());
+        member.verifyMemberPassword(updatePasswordCommand.getOriginalPassword());
+        member.updatePassword(updatePasswordCommand.getNewPassword());
     }
 
     @Transactional

--- a/src/main/java/hanium/englishfairytale/member/application/dto/MemberUpdatePasswordCommand.java
+++ b/src/main/java/hanium/englishfairytale/member/application/dto/MemberUpdatePasswordCommand.java
@@ -11,5 +11,6 @@ import lombok.NoArgsConstructor;
 @Builder
 public class MemberUpdatePasswordCommand {
     Long memberId;
-    String password;
+    String originalPassword;
+    String newPassword;
 }

--- a/src/main/java/hanium/englishfairytale/member/domain/Member.java
+++ b/src/main/java/hanium/englishfairytale/member/domain/Member.java
@@ -3,6 +3,7 @@ package hanium.englishfairytale.member.domain;
 import hanium.englishfairytale.exception.BusinessException;
 import hanium.englishfairytale.exception.code.ErrorCode;
 import hanium.englishfairytale.member.application.dto.MemberLoginCommand;
+import hanium.englishfairytale.member.application.dto.MemberUpdatePasswordCommand;
 import hanium.englishfairytale.tale.domain.Tale;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -90,9 +91,15 @@ public class Member {
         this.image = null;
     }
 
-    public void verifyCorrectPassword(MemberLoginCommand memberLoginCommand) {
-        if (!Objects.equals(password, memberLoginCommand.getPassword())) {
+    public void verifyMemberEmailAndPassword(MemberLoginCommand memberLoginCommand) {
+        if (!Objects.equals(password, memberLoginCommand.getPassword()) || !Objects.equals(email, memberLoginCommand.getEmail())) {
             throw new BusinessException(ErrorCode.LOGIN_FAILED);
+        }
+    }
+
+    public void verifyMemberPassword(String originalPassword) {
+        if (!Objects.equals(password, originalPassword)) {
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
         }
     }
 }

--- a/src/main/java/hanium/englishfairytale/member/infra/http/MemberController.java
+++ b/src/main/java/hanium/englishfairytale/member/infra/http/MemberController.java
@@ -53,9 +53,9 @@ public class MemberController {
         memberCommandService.updateNickname(memberId, nickname);
     }
 
-    @PatchMapping("/password")
-    public void updatePassword(@Validated @RequestBody MemberUpdatePasswordDto updatePasswordDto) {
-        memberCommandService.updatePassword(toPasswordUpdateCommand(updatePasswordDto));
+    @PatchMapping("/password/{memberId}")
+    public void updatePassword(@PathVariable Long memberId ,@Validated @RequestBody MemberUpdatePasswordDto updatePasswordDto) {
+        memberCommandService.updatePassword(toPasswordUpdateCommand(memberId, updatePasswordDto));
     }
 
     @PatchMapping("/{memberId}/image")
@@ -72,8 +72,8 @@ public class MemberController {
         return converter.toCommand(memberRegisterDto, image);
     }
 
-    private MemberUpdatePasswordCommand toPasswordUpdateCommand(MemberUpdatePasswordDto updatePasswordDto) {
-        return converter.toCommand(updatePasswordDto);
+    private MemberUpdatePasswordCommand toPasswordUpdateCommand(Long memberId, MemberUpdatePasswordDto updatePasswordDto) {
+        return converter.toCommand(memberId, updatePasswordDto);
     }
 
     private MemberImageUpdateCommand toImageUpdateCommand(Long memberId, MultipartFile image) {

--- a/src/main/java/hanium/englishfairytale/member/infra/http/MemberDtoConverter.java
+++ b/src/main/java/hanium/englishfairytale/member/infra/http/MemberDtoConverter.java
@@ -23,10 +23,11 @@ public class MemberDtoConverter {
                 .build();
     }
 
-    public MemberUpdatePasswordCommand toCommand(MemberUpdatePasswordDto dto) {
+    public MemberUpdatePasswordCommand toCommand(Long memberId, MemberUpdatePasswordDto dto) {
         return MemberUpdatePasswordCommand.builder()
-                .memberId(dto.getMemberId())
-                .password(dto.getPassword())
+                .memberId(memberId)
+                .originalPassword(dto.getOriginalPassword())
+                .newPassword(dto.getNewPassword())
                 .build();
     }
 

--- a/src/main/java/hanium/englishfairytale/member/infra/http/dto/MemberUpdatePasswordDto.java
+++ b/src/main/java/hanium/englishfairytale/member/infra/http/dto/MemberUpdatePasswordDto.java
@@ -12,8 +12,9 @@ import javax.validation.constraints.Pattern;
 @AllArgsConstructor
 public class MemberUpdatePasswordDto {
     @NotNull
-    private Long memberId;
+    @Pattern(regexp = "^(?i)(?=.*[a-zA-Z])(?=.*[0-9])[a-zA-Z0-9]{2,10}$")
+    private String originalPassword;
     @NotNull
     @Pattern(regexp = "^(?i)(?=.*[a-zA-Z])(?=.*[0-9])[a-zA-Z0-9]{2,10}$")
-    private String password;
+    private String newPassword;
 }

--- a/src/main/java/hanium/englishfairytale/tale/application/dto/TalesInfo.java
+++ b/src/main/java/hanium/englishfairytale/tale/application/dto/TalesInfo.java
@@ -14,11 +14,16 @@ public class TalesInfo {
 
     private Long taleId;
     private String title;
+    private String imgUrl;
+    private String imgStatus;
     private List<String> keywords;
 
     public TalesInfo(Tale tale, List<Keyword> keywordList) {
         this.taleId = tale.getId();
         this.title = tale.getTitle();
+        this.imgUrl = tale.getImage().getTaleImage() == null ? null : tale.getImage().getUrl();
+        this.imgStatus = tale.getImageStatus();
+
         keywords = new ArrayList<>();
         for (Keyword keyword : keywordList) {
             keywords.add(keyword.getWord());


### PR DESCRIPTION
1. 비밀번호 변경시, 기존의 비밀번호와 비교하여 예외처리하는 코드 추가
    -> DTO 수정 및 PathVariable 데이터 추가
2. 동화 전체 조회시 이미지url 및 Image Status가 함께 출력되도록 수정