### PR TITLE
hotfix: "이미지 없이 회원가입을 하는 경우 버그 해결"

### DIFF
--- a/src/main/java/hanium/englishfairytale/member/application/MemberCommandService.java
+++ b/src/main/java/hanium/englishfairytale/member/application/MemberCommandService.java
@@ -97,7 +97,7 @@ public class MemberCommandService {
     }
 
     private boolean checkImageEmpty(MemberRegisterCommand memberRegisterCommand) {
-        return memberRegisterCommand.getImage().isEmpty();
+        return memberRegisterCommand.getImage()==null;
     }
 
     private Long saveMember(Member member) {

--- a/src/main/java/hanium/englishfairytale/member/infra/http/MemberController.java
+++ b/src/main/java/hanium/englishfairytale/member/infra/http/MemberController.java
@@ -27,7 +27,7 @@ public class MemberController {
 
     @PostMapping("/register")
     public Long register(@Validated @RequestPart MemberRegisterDto memberRegisterDto,
-                                         @RequestPart MultipartFile image) {
+                                         @RequestPart(required = false) MultipartFile image) {
         return memberCommandService.register(toCreateCommand(memberRegisterDto, image));
     }
 


### PR DESCRIPTION
이미지 없이 회원가입을 하는 경우 요청파트에서 image부분이 존재하지 않아 image부분을 option으로 설정, image가 없을 떄의 처리를 isEmpty()에서 null과 비교연산을 이용