### PR TITLE
hotfix: 동화생성 이미지 null 오류 해결

### DIFF
--- a/src/main/java/hanium/englishfairytale/tale/application/TaleCommandService.java
+++ b/src/main/java/hanium/englishfairytale/tale/application/TaleCommandService.java
@@ -76,7 +76,7 @@ public class TaleCommandService {
 
     private Tale createTale(TaleCreateCommand taleCreateCommand) {
         Member member = findMember(taleCreateCommand.getMemberId());
-        CreatedTale createdTale = createEnglishTale(taleCreateCommand);
+        CreatedTale createdTale = createTaleByLLM(taleCreateCommand);
         return Tale.builder()
                 .title(createdTale.getTitle())
                 .engTale(createdTale.getEngTale())
@@ -91,7 +91,7 @@ public class TaleCommandService {
                 .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND, memberId));
     }
 
-    private CreatedTale createEnglishTale(TaleCreateCommand taleCreateCommand) {
+    private CreatedTale createTaleByLLM(TaleCreateCommand taleCreateCommand) {
         verifyInputKeywords(taleCreateCommand);
         return taleManageService.post(taleCreateCommand.getModel(), taleCreateCommand.getKeywords());
     }
@@ -102,7 +102,7 @@ public class TaleCommandService {
     }
 
     private TaleCreateResponse saveTaleAndKeywords(Tale tale, List<Keyword> keywords, MultipartFile image) {
-        if (!image.isEmpty()) {
+        if (image != null) {
             tale.putImage(createAndSaveTaleImage(image));
         }
         saveTaleKeywords(tale, keywords);

--- a/src/main/java/hanium/englishfairytale/tale/infra/http/TaleController.java
+++ b/src/main/java/hanium/englishfairytale/tale/infra/http/TaleController.java
@@ -23,7 +23,7 @@ public class TaleController {
 
     @PostMapping("create")
     public TaleCreateResponse create(@Validated @RequestPart TaleCreateDto taleCreateDto,
-                                                     @RequestPart MultipartFile image) {
+                                                     @RequestPart(required = false) MultipartFile image) {
         return taleCommandService.create(toCreateCommand(taleCreateDto, image));
     }
 


### PR DESCRIPTION
1. @RequestPart(required=false)를 통해 null 값으로 들어와도 가능하게 로직을 수정
2. '== null'을 통해 null으로 왔는지 체크하는 코드 구성
3. LLM 기술을 이용하여 들고오는 메서드를 역할에 맞게 메서드명을 수정: createEnglishTale() -> createTaleByLLM()